### PR TITLE
Added three new commands: StandEvery, StandEnable, StandDisable.

### DIFF
--- a/lua/stand.lua
+++ b/lua/stand.lua
@@ -5,6 +5,7 @@ function M.setup(options)
 	options.minute_interval = (options.minute_interval or 60) * 60 * 1000
 
 	local timer = vim.loop.new_timer()
+	local enabled = true
 
 	local has_notify, notify = pcall(require, "notify")
 	if has_notify then
@@ -35,7 +36,7 @@ function M.setup(options)
 				minutes_remaining == 1 and "minute" or "minutes"
 			)
 		)
-	end, {})
+	end, { desc = "Display time remaining until next stand." })
 
 	vim.api.nvim_create_user_command("StandNow", function()
 		if has_notify then
@@ -44,7 +45,37 @@ function M.setup(options)
 
 		timer:stop()
 		timer:again()
-	end, {})
+	end, { "Stand, dismissing any notifications and restarting the timer." })
+
+	vim.api.nvim_create_user_command("StandEvery", function(opts)
+		options.minute_interval = tonumber(opts.args) * 60 * 1000
+		local remaining = timer:get_due_in()
+		timer:stop()
+		timer:start(remaining, options.minute_interval, vim.schedule_wrap(on_timer)) -- Start timer with new time
+	end, { desc = "Set the stand interval in minutes for future timers.", nargs = 1 })
+
+	vim.api.nvim_create_user_command("StandDisable", function()
+		if not enabled then
+			vim.print("Standing already disabled.")
+			return
+		end
+		timer:stop()
+		vim.print("Standing disabled.")
+		enabled = false
+		if has_notify then
+			require("notify").dismiss()
+		end
+	end, { desc = "Disable the stand timer." })
+
+	vim.api.nvim_create_user_command("StandEnable", function()
+		if enabled then
+			vim.print("Standing already enabled.")
+			return
+		end
+		timer:again()
+		vim.print("Standing enabled.")
+		enabled = true
+	end, { desc = "Enable the stand timer." })
 end
 
 return M

--- a/readme.md
+++ b/readme.md
@@ -29,3 +29,9 @@ require("stand").setup({
 `StandWhen` - Display time remaining until next stand
 
 `StandNow` - Stand, dismissing any notifications and restarting the timer
+
+`StandEvery` - Set the stand interval in minutes for future timers
+
+`StandDisable` - Disable the stand timer
+
+`StandEnable` - Enable the stand timer


### PR DESCRIPTION
Hello, I really liked the idea of this plugin because I spend too much time at my desk. However, I would like to be able to turn off the stand timer temporarily when I'm in the zone, as well as change the timer interval without restarting my config. I have added three new commands to achieve this functionality.

### Stand Disable
This command will disable the stand timer and dismiss all notifications in a similar way to `StandNow`. It does not restart the timer though.

### Stand Enable
Once the timer has been disabled using `StandDisable`, this command will restart it so that it functions just like it did at nvim startup.

### StandEvery
This command takes a single argument, the desired stand timer interval in minutes. It changes the timer interval to use the newly passed minute interval at the next round, without changing the remaining time left on the current timer.

I also added an internal 'enabled' state (boolean variable) to track whether the timer was currently enabled (to prevent double-usage of the enable/disable commands). This has been working exactly as I expect in my config.