### PR TITLE
fix: Add desc key to StandNow user command definition

### DIFF
--- a/lua/stand.lua
+++ b/lua/stand.lua
@@ -45,7 +45,7 @@ function M.setup(options)
 
 		timer:stop()
 		timer:again()
-	end, { "Stand, dismissing any notifications and restarting the timer." })
+	end, { desc = "Stand, dismissing any notifications and restarting the timer." })
 
 	vim.api.nvim_create_user_command("StandEvery", function(opts)
 		options.minute_interval = tonumber(opts.args) * 60 * 1000


### PR DESCRIPTION
This fixes a bug in which the plugin fails to load with the error `Invalid key: 1`